### PR TITLE
Added source-filesystem entry for src/pages to allow graphql mdx queries

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,6 +22,13 @@ module.exports = {
         path: `${__dirname}/src/images`,
       },
     },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `pages`,
+        path: `${__dirname}/src/pages`
+      }
+    },
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {


### PR DESCRIPTION
Resolve #1.

Now when you initially download the starter, you can access `mdx` and `allMdx` in any graphql query